### PR TITLE
Misc fixes to make selecta compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,12 @@
 [root]
 name = "selecta"
 version = "0.0.1"
+dependencies = [
+ "regex 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ name = "selecta"
 version = "0.0.1"
 authors = ["James Sadler <freshtonic@gmail.com>"]
 
+[dependencies]
+regex = "0.1.14"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -28,7 +28,7 @@ impl<'a> Configuration<'a> {
 mod test {
 
     use super::Configuration;
-    use std::io::File;
+    use std::old_io::File;
 
     // Choices
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-
 #![allow(unstable)]
 #![feature(box_syntax)]
 
@@ -7,5 +6,5 @@ mod score;
 
 mod configuration;
 
-// fn main() {
-// }
+fn main() {
+}


### PR DESCRIPTION
- Adds the regex crate as a dependency to be pulled from crates.io
- Uncomments the main function so `cargo build` compiles everything
- Until the new std::io API is worked out use std::old_io
