### PR TITLE
Added regex Crate dependency. Updated Readme with requirement for latest Rust and Cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,12 @@
 [root]
 name = "selecta"
 version = "0.0.1"
+dependencies = [
+ "regex 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ test = true
 doc = false
 
 [dependencies]
-regex = "*"
+regex = "0.1.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ name = "selecta_rs"
 doctest = false
 test = true
 doc = false
+
+[dependencies]
+regex = "*"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ because it's small, easy to understand and well-specced.
 
 # Requirements
 
-The latest Rust and Cargo versions must be installed. Update the to the latest combined Rust and Cargo Nightly build regularly with the command: ```curl -sS https://static.rust-lang.org/rustup.sh | sudo bash```
+The latest Rust and Cargo versions must be installed. Update to the latest combined Rust and Cargo Nightly build regularly with the command: ```curl -sS https://static.rust-lang.org/rustup.sh | sudo bash```
 
 It has been tested against the Rust 1.0.0-alpha version and successfully compiles with these Nightly versions:
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ because it's small, easy to understand and well-specced.
 
 # Requirements
 
-Rust and Cargo must be installed.
+The latest Rust and Cargo versions must be installed. Update the to the latest combined Rust and Cargo Nightly build regularly with the command: ```curl -sS https://static.rust-lang.org/rustup.sh | sudo bash```
 
-I've only tested against the Rust 1.0.0-alpha version.
+It has been tested against the Rust 1.0.0-alpha version and successfully compiles with these Nightly versions:
+
+ - rustc 1.0.0-nightly (30e1f9a1c 2015-03-14) (built 2015-03-15)
+ - cargo 0.0.1-pre-nightly (07cd618 2015-03-12) (built 2015-03-13)
 
 # Build and run the specs
 


### PR DESCRIPTION
Refer to a ticket that was raised on The Rust Discussion Forum related to changes in this PR [here](http://users.rust-lang.org/t/regex-crate-dependency-causes-error/664)
